### PR TITLE
Deck cards content

### DIFF
--- a/src/features/srs/decks/one/cards/field-types/card-content-property-text.tsx
+++ b/src/features/srs/decks/one/cards/field-types/card-content-property-text.tsx
@@ -1,6 +1,6 @@
 import { EditbarMode } from 'features/app/ui/editbar/editbar';
 import TextInput from 'features/app/ui/form/text-input';
-import { Field, CardFieldContent } from 'features/srs/srs-types';
+import { CardFieldValue } from 'features/srs/srs-types';
 import { useTranslation } from 'react-i18next';
 
 const PREFIX = 'srs:decks.one.cards.many.properties.value';
@@ -8,9 +8,9 @@ const PREFIX = 'srs:decks.one.cards.many.properties.value';
 interface Props {
   className?: string;
   label?: React.ReactNode;
-  name: Field['id'];
+  name: string;
   mode: EditbarMode;
-  value: CardFieldContent;
+  value: CardFieldValue;
   onChange: (value: any) => void;
 }
 
@@ -23,7 +23,7 @@ export default function CardContentPropertyText(
     <TextInput
       className={className}
       label={label}
-      name={`${name}`}
+      name={name}
       placeholder={t(`${PREFIX}.placeholder`)}
       readOnly={mode === 'view'}
       data-field-type="text"

--- a/src/features/srs/decks/one/cards/field-types/card-content-property.tsx
+++ b/src/features/srs/decks/one/cards/field-types/card-content-property.tsx
@@ -11,7 +11,7 @@ interface Props {
   className?: string;
   label?: React.ReactNode;
   type: Field['type'];
-  name: Field['id'];
+  name: string;
   mode: EditbarMode;
   value: any;
   onChange: (value: any) => void;

--- a/src/features/srs/decks/one/cards/slider/deck-cards-slider-item.tsx
+++ b/src/features/srs/decks/one/cards/slider/deck-cards-slider-item.tsx
@@ -25,7 +25,7 @@ export default function DeckCardsSliderItem(
   const { status: { editbar: { mode } } } = state.cards;
 
   const handleChange = useCallback(({ target: { name, value } }) => {
-    dispatch(['cardUpdated', { index, property: name, value }]);
+    dispatch(['cardUpdated', { index, path: name, value }]);
   }, [index]);
 
   const handleDeleteClick = useCallback(() => {
@@ -42,10 +42,10 @@ export default function DeckCardsSliderItem(
           key={field.id}
           className="deck-cards__slider-card-property"
           label={field.title}
-          name={field.id}
+          name={`content[${field.id}][0].text`}
           type={field.type}
           mode={mode}
-          value={card.content[field.id || 0] || {}}
+          value={card?.content?.[field.id]?.[0] || {}}
           onChange={handleChange}
         />
       ))}

--- a/src/features/srs/decks/one/cards/table/deck-cards-table-item.tsx
+++ b/src/features/srs/decks/one/cards/table/deck-cards-table-item.tsx
@@ -24,7 +24,7 @@ export default function DeckCardsTableItem(
   const { status: { display: { showProgress } = {}, editbar: { mode } } } = state.cards;
 
   const handleChange = useCallback(({ target: { name, value } }) => {
-    dispatch(['cardUpdated', { index, property: name, value }]);
+    dispatch(['cardUpdated', { index, path: name, value }]);
   }, [index]);
 
   const handleDeleteClick = useCallback(() => {
@@ -51,10 +51,10 @@ export default function DeckCardsTableItem(
         >
           <DeckCardsProperty
             className="deck-cards__table-item-property"
-            name={field.id}
+            name={`content.${field.id}.[0].text`}
             type={field.type}
             mode={mode}
-            value={card.content[field.id || 0] || {}}
+            value={card?.content?.[field.id]?.[0] || {}}
             onChange={handleChange}
           />
         </td>

--- a/src/features/srs/decks/one/deck-reducer.ts
+++ b/src/features/srs/decks/one/deck-reducer.ts
@@ -322,16 +322,14 @@ function cardAdded(draft: State) {
 
 interface CardUpdatedPayload {
   index: number;
-  property: Field['id'];
+  path: string;
   value: any;
 }
 
-function cardUpdated(draft: State, { index, property, value }: CardUpdatedPayload) {
-  const { data, status } = draft.cards;
-  const { cards } = data || {};
-  if (cards && property) {
-    if (!cards[index].content[property]) cards[index].content[property] = { text: '' };
-    cards[index].content[property].text = value;
+function cardUpdated(draft: State, { index, path, value }: CardUpdatedPayload) {
+  const { data: { cards } = {}, status } = draft.cards;
+  if (cards?.[index] && path) {
+    set(cards[index], path, value);
     entityUpdated(status);
     updateTabsStatus(draft);
   }

--- a/src/features/srs/decks/one/fields/deck-fields-domain.ts
+++ b/src/features/srs/decks/one/fields/deck-fields-domain.ts
@@ -45,8 +45,8 @@ export const getFieldRoleIdByValue = (value: string) => (
 export function getFieldDefaultContent(field: Field) {
   switch (getFieldTypeValueById(field.type)) {
     case 'text':
-      return { text: '' };
+      return [{ text: '' }];
     default:
-      return {};
+      return [{ text: '' }];
   }
 }

--- a/src/features/srs/lessons/lesson/action-types/lesson-action-typetest-domain.ts
+++ b/src/features/srs/lessons/lesson/action-types/lesson-action-typetest-domain.ts
@@ -34,7 +34,7 @@ export const typeTestProcessings: Record<string, TypeTestProcessing> = {
  */
 export function isTypeTestResultCorrect(field: LessonField) {
   const inputValue = field.value || '';
-  const actualValue = field?.content?.text || '';
+  const actualValue = field?.content?.[0]?.text || '';
   // compare values without processing first
   if (inputValue === actualValue) return true;
   // go through processing pipeline and compare

--- a/src/features/srs/lessons/lesson/field-types/lesson-field-text.tsx
+++ b/src/features/srs/lessons/lesson/field-types/lesson-field-text.tsx
@@ -8,6 +8,7 @@ export default function LessonFieldText(
   { type, field, value, readonly, isError, onChange }: Props,
 ) {
   const label = field?.settings?.actions?.[type]?.isLabelVisible && field.title;
+  const content = field?.content?.[0]?.text;
 
   return (
     <li className="lesson__fields-item">
@@ -20,10 +21,10 @@ export default function LessonFieldText(
           )}
           <span
             className="lesson__field-value"
-            data-is-empty={!(isError ? value : field.content?.text)}
+            data-is-empty={!(isError ? value : content)}
             data-is-incorrect={isError}
           >
-            {(isError ? value : field.content?.text) || t(`${PREFIX}.empty`)}
+            {(isError ? value : content) || t(`${PREFIX}.empty`)}
           </span>
         </div>
       ) : (
@@ -32,7 +33,7 @@ export default function LessonFieldText(
           label={label}
           name={`${field.id}`}
           value={value}
-          placeholder={isError ? field.content.text : ''}
+          placeholder={isError ? content : ''}
           readOnly={readonly}
           autoFocus={field.isFocused}
           data-is-correct={field.isCorrect === true}
@@ -43,10 +44,10 @@ export default function LessonFieldText(
         <div className="lesson__field">
           <span
             className="lesson__field-value"
-            data-is-empty={!field.content?.text}
+            data-is-empty={!content}
             data-is-correct="true"
           >
-            {field.content?.text || t(`${PREFIX}.empty`)}
+            {content || t(`${PREFIX}.empty`)}
           </span>
         </div>
       )}

--- a/src/features/srs/lessons/lessons-domain.ts
+++ b/src/features/srs/lessons/lessons-domain.ts
@@ -240,7 +240,7 @@ function makeLessonFields(fields: Field[], card: LessonCard, type: PhaseAction['
   const lessonFields = card && fields.map((field) => (
     {
       ...field,
-      content: card.content[`${field.id}`] || getFieldDefaultContent(field),
+      content: card?.content?.[`${field.id}`] || getFieldDefaultContent(field),
       isTested: (testedRole === getFieldRoleValueById(field.role)),
     }
   ));

--- a/src/features/srs/srs-schema.json
+++ b/src/features/srs/srs-schema.json
@@ -329,11 +329,16 @@
       "propertyNames": { "pattern": "^[1-9][0-9]*" },
       "patternProperties": {
         "": {
-          "type": "object",
-          "properties": {
-            "text": { "type": "string" }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "text": { "type": "string" }
+            },
+            "additionalProperties": false
           },
-          "additionalProperties": false
+          "minItems": 1,
+          "maxItems": 10
         }
       }
     },

--- a/src/features/srs/srs-types.ts
+++ b/src/features/srs/srs-types.ts
@@ -54,7 +54,7 @@ export interface FieldSettings {
 
 export interface Card {
   id: number;
-  content: Record<string, CardFieldContent>;
+  content: Record<string, CardFieldValue[]>;
   meta?: {
     status: 'initial' | 'learning' | 'completed';
     divel?: {
@@ -72,7 +72,7 @@ interface CardProgress {
   dueAt?: string;
 }
 
-export interface CardFieldContent {
+export interface CardFieldValue {
   text: string;
 }
 
@@ -199,7 +199,7 @@ export interface LessonField {
   type: Field['type'];
   role: Field['role'];
   settings: FieldSettings;
-  content: CardFieldContent;
+  content: CardFieldValue[];
   value?: string;
   isTested?: boolean;
   isCorrect?: boolean;


### PR DESCRIPTION
Updates to card content field value to be an array of objects instead of object.
This update will enable multiple field values for a card in the future.
Update includes:
1.  Updates to srs-schema and srs-types
2. Card components and deck reducer updates to be in sync with schema changes
3. Lesson component updates to be in sync with schema changes